### PR TITLE
fix(server): make tests run against a clean database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,7 @@ jobs:
           cache: npm
           cache-dependency-path: server/package-lock.json
       - run: npm ci
-      - run: npm run generate
-      # Not `npm test`: the suite starts an Express listener that afterAll never
-      # closes, so Jest hangs on the open handle instead of exiting. --forceExit
-      # works around it; fixing the teardown in src/tests would let this go back
-      # to `npm test`.
-      - run: npx jest --forceExit
+      - run: npm test
 
   website:
     name: Website lint + build

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -4,7 +4,6 @@ import { ScaleModel } from '../models/scale';
 import { schema } from "../schema"
 import { connect, disconnect } from 'mongoose';
 import  ScaleQueries from "./queries/scale"
-import express from "express"
 import { ERROR_LIST } from '../utils/error-handler.helper';
 
 type ScaleProps = {
@@ -34,19 +33,18 @@ describe("Scale", ()=>{
   let testScaleData: any 
 
   beforeAll(async ()=>{
-    const app = express()
     // Apollo defaults context to {} when none is given. {} is truthy, so the
     // `if(!ctx)` guard in the resolvers passes and they run with ctx.id
     // undefined — silently operating on a user that does not exist.
     testServer = new ApolloServer({
       schema,
-      express: app,
       context: ()=> ({ id: testUser.id })
     } as any)
 
-    const port = process.env.PORT || 3002;
-    connect(process.env.DB_CONNECTION as string, { useNewUrlParser: true, useUnifiedTopology: true, dbName: process.env.DB_NAME })
-      .then(()=>{app.listen(port, ()=>console.log(`Scale test server started on port ${port}`))})
+    // Awaited: the model calls below used to race this, relying on mongoose
+    // command buffering. No express listener either — executeOperation runs
+    // in-process, and the listener was never closed, so jest hung on it.
+    await connect(process.env.DB_CONNECTION as string, { useNewUrlParser: true, useUnifiedTopology: true, dbName: process.env.DB_NAME })
 
     testUser = await new UserModel({
       email: "scaleTestEmail@gmail.com",
@@ -72,7 +70,8 @@ describe("Scale", ()=>{
     await UserModel.findByIdAndRemove(testUser.id)
       .catch((err: unknown)=>console.log("Failed to delete test user: "+err))
 
-    disconnect()
+    await testServer.stop()
+    await disconnect()
   })
 
   it("Create a scale for user with userId", async ()=>{

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -116,7 +116,9 @@ describe("Scale", ()=>{
   })
 
   it("Update a scale for user with userId", async ()=>{
-    const newScale = await ScaleModel.create(testScale)
+    // Not ScaleModel.create(testScale): that clones the existing document
+    // including its _id, so the insert collides with the scale it copied.
+    const newScale = await ScaleModel.create({...testScaleData, userId: testUser.id})
     
     const expectedUpdatedScale = {
       id: newScale.id,

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -1,6 +1,7 @@
 import { ApolloServer } from 'apollo-server';
 import { UserModel } from '../models/user';
 import { ScaleModel } from '../models/scale';
+import { ScaleOrderModel } from '../models/scaleOrder';
 import { schema } from "../schema"
 import { connect, disconnect } from 'mongoose';
 import  ScaleQueries from "./queries/scale"
@@ -65,10 +66,9 @@ describe("Scale", ()=>{
       .catch((err: unknown)=>console.log("Failed to create test scale: "+err))
   })
   afterAll(async ()=>{
-    await ScaleModel.findByIdAndRemove(testScale.id)
-      .catch((err: unknown)=>console.log("Failed to delete test scale: "+err))
+    await ScaleModel.deleteMany({userId: testUser.id})
+    await ScaleOrderModel.deleteMany({userId: testUser.id})
     await UserModel.findByIdAndRemove(testUser.id)
-      .catch((err: unknown)=>console.log("Failed to delete test user: "+err))
 
     await testServer.stop()
     await disconnect()
@@ -88,7 +88,10 @@ describe("Scale", ()=>{
     expect(compareScales({...testScaleData, userId: testUser.id}, scaleObj)).toBeTruthy()
 
     await ScaleModel.findByIdAndRemove(scaleObj.id)
-      .catch(()=>console.log("Create scale test cleanup error: Failed to delete test scale."))
+    // createScale also appends the new id to the user's ScaleOrder. Deleting
+    // only the scale leaves a dangling id there, and GET_SCALES maps its
+    // results through that order — yielding null in a non-null list.
+    await ScaleOrderModel.deleteMany({userId: testUser.id})
   })
   it("Reject creating scale for nonexistant userID", async ()=>{
     const fakeUserId = "fAk3us3R1d" 

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -93,14 +93,15 @@ describe("Scale", ()=>{
     // results through that order — yielding null in a non-null list.
     await ScaleOrderModel.deleteMany({userId: testUser.id})
   })
-  it("Reject creating scale for nonexistant userID", async ()=>{
-    const fakeUserId = "fAk3us3R1d" 
-    const response = await testServer.executeOperation({
-      query: ScaleQueries.CREATE_SCALE,
-      variables: { ...testScaleData, userId: fakeUserId }
-    })
-    expect(response.errors?.at(0)?.extensions?.code).toBe(ERROR_LIST.NOT_FOUND.code)
-  })
+  // The three "nonexistant userId" tests passed a userId variable the schema
+  // no longer declares, so they never exercised a missing user at all. They
+  // can't be restored as written: UserModel.findById resolves to null for a
+  // missing document instead of rejecting, so the .catch in Scale.ts (lines
+  // 70, 117, 145) never runs and NOT_FOUND is unreachable. Restore these once
+  // the resolvers check for a null user.
+  it.todo("Reject creating a scale when the authenticated user no longer exists")
+  it.todo("Rejects getting scales when the authenticated user no longer exists")
+  it.todo("Rejects updating a scale when the authenticated user no longer exists")
 
 
   it("Retrieves all scales from user with userId", async ()=>{
@@ -113,14 +114,6 @@ describe("Scale", ()=>{
 
     expect(response.errors).toBe(undefined)
     expect(scales.length).toBe(numScales)
-  })
-
-  it("Rejects getting scales of a nonexistant userId", async ()=>{
-    const response = await testServer.executeOperation({
-      query: ScaleQueries.GET_SCALES,
-      variables: {userId: "fakeUserId"}
-    })
-    expect(response.errors?.at(0)?.extensions?.code).toBe(ERROR_LIST.NOT_FOUND.code)
   })
 
   it("Update a scale for user with userId", async ()=>{
@@ -148,14 +141,6 @@ describe("Scale", ()=>{
     await ScaleModel.findByIdAndRemove(newScale.id)
       .catch(()=>console.log("Create scale test cleanup error: Failed to delete test scale."))
   })
-  it("Rejects updating a scale for a nonexistant userId", async ()=>{
-    const response = await testServer.executeOperation({
-      query: ScaleQueries.UPDATE_SCALE,
-      variables: {...testScaleData, id: testScale.id, userId: "fakeUserId"} 
-    })
-    expect(response.errors?.at(0)?.extensions?.code).toBe(ERROR_LIST.NOT_FOUND.code)
-  })
-
   it("Rejects updating a scale for a nonexistant scaleId", async ()=>{
     const response = await testServer.executeOperation({
       query: ScaleQueries.UPDATE_SCALE,

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -35,9 +35,13 @@ describe("Scale", ()=>{
 
   beforeAll(async ()=>{
     const app = express()
+    // Apollo defaults context to {} when none is given. {} is truthy, so the
+    // `if(!ctx)` guard in the resolvers passes and they run with ctx.id
+    // undefined — silently operating on a user that does not exist.
     testServer = new ApolloServer({
       schema,
-      express: app
+      express: app,
+      context: ()=> ({ id: testUser.id })
     } as any)
 
     const port = process.env.PORT || 3002;

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -54,15 +54,16 @@ describe("Scale", ()=>{
       token: "scaleNonJWTTestToken"
     }).save().catch((err: unknown)=>console.log("Failed to create test user: "+err))
 
+    // No userId: the mutation stopped accepting it when auth moved to the JWT,
+    // so GraphQL discards it. The resolver stamps ctx.id on the scale instead.
     testScaleData = {
-      userId: testUser?.id,
       goal: "Test Scale",
       sliderValue: 60,
       chasingSuccessDescription: "test chasing success description",
       avoidingFailureDescription: "test avoiding failure description",
     }
 
-    testScale = await new ScaleModel(testScaleData).save()
+    testScale = await new ScaleModel({...testScaleData, userId: testUser.id}).save()
       .catch((err: unknown)=>console.log("Failed to create test scale: "+err))
   })
   afterAll(async ()=>{
@@ -81,7 +82,7 @@ describe("Scale", ()=>{
     })
     const scaleObj = response.data?.createScale
 
-    expect(compareScales(testScaleData, scaleObj)).toBeTruthy()
+    expect(compareScales({...testScaleData, userId: testUser.id}, scaleObj)).toBeTruthy()
 
     await ScaleModel.findByIdAndRemove(scaleObj.id)
       .catch(()=>console.log("Create scale test cleanup error: Failed to delete test scale."))
@@ -100,8 +101,7 @@ describe("Scale", ()=>{
     const numScales = await ScaleModel.find({userId: testScale.userId}).count()
 
     const response = await testServer.executeOperation({
-      query: ScaleQueries.GET_SCALES,
-      variables: {userId: testScale.userId}
+      query: ScaleQueries.GET_SCALES
     })
     const scales = response.data?.scales
     expect(scales.length).toBe(numScales)
@@ -120,7 +120,6 @@ describe("Scale", ()=>{
     
     const expectedUpdatedScale = {
       id: newScale.id,
-      userId: testScale.userId,
       goal: "Updated Scale",
       sliderValue: 2,
       chasingSuccessDescription: "Updated chasing success description",
@@ -132,7 +131,7 @@ describe("Scale", ()=>{
       variables: expectedUpdatedScale
     })
     const updatedScale = response.data?.updateScale
-    expect(compareScales(expectedUpdatedScale, updatedScale)).toBeTruthy()
+    expect(compareScales({...expectedUpdatedScale, userId: testUser.id}, updatedScale)).toBeTruthy()
 
     await ScaleModel.findByIdAndRemove(newScale.id)
       .catch(()=>console.log("Create scale test cleanup error: Failed to delete test scale."))

--- a/server/src/tests/scale.test.ts
+++ b/server/src/tests/scale.test.ts
@@ -82,6 +82,10 @@ describe("Scale", ()=>{
     })
     const scaleObj = response.data?.createScale
 
+    // Before comparing: compareScales returns false for undefined input, so a
+    // failed operation would otherwise surface as "scales didn't match"
+    // instead of the actual GraphQL error.
+    expect(response.errors).toBe(undefined)
     expect(compareScales({...testScaleData, userId: testUser.id}, scaleObj)).toBeTruthy()
 
     await ScaleModel.findByIdAndRemove(scaleObj.id)
@@ -104,6 +108,8 @@ describe("Scale", ()=>{
       query: ScaleQueries.GET_SCALES
     })
     const scales = response.data?.scales
+
+    expect(response.errors).toBe(undefined)
     expect(scales.length).toBe(numScales)
   })
 
@@ -133,6 +139,8 @@ describe("Scale", ()=>{
       variables: expectedUpdatedScale
     })
     const updatedScale = response.data?.updateScale
+
+    expect(response.errors).toBe(undefined)
     expect(compareScales({...expectedUpdatedScale, userId: testUser.id}, updatedScale)).toBeTruthy()
 
     await ScaleModel.findByIdAndRemove(newScale.id)

--- a/server/src/tests/user.test.ts
+++ b/server/src/tests/user.test.ts
@@ -1,7 +1,6 @@
 import { ApolloServer } from 'apollo-server';
 import { UserModel } from "../models/user"
 import { schema } from "../schema"
-import express from "express"
 import { connect, disconnect } from 'mongoose';
 import UserQueries  from "./queries/user"
 import { ERROR_LIST } from '../utils/error-handler.helper';
@@ -15,16 +14,11 @@ describe("Login/Register", ()=>{
   }
 
   beforeAll(async ()=>{
-    const app = express()
+    testServer = new ApolloServer({ schema } as any)
 
-    testServer = new ApolloServer({
-      schema,
-      express: app
-    } as any)
-
-    const port = process.env.PORT || 3003;
-    connect(process.env.DB_CONNECTION as string, { useNewUrlParser: true, useUnifiedTopology: true, dbName: process.env.DB_NAME })
-        .then(()=>{app.listen(port, ()=>console.log(`User test server started on port ${port}`))})
+    // Awaited, and without an express listener: executeOperation runs
+    // in-process, and the listener was never closed, so jest hung on it.
+    await connect(process.env.DB_CONNECTION as string, { useNewUrlParser: true, useUnifiedTopology: true, dbName: process.env.DB_NAME })
 
     // make sure we are only making queries to the test database
     const env = process.env.DB_NAME
@@ -37,7 +31,7 @@ describe("Login/Register", ()=>{
   })
   afterAll(async ()=>{
     await testServer.stop()
-    disconnect()
+    await disconnect()
   })
 
   it("Registers a new user", async ()=>{

--- a/server/src/tests/user.test.ts
+++ b/server/src/tests/user.test.ts
@@ -13,6 +13,13 @@ describe("Login/Register", ()=>{
     password: "test"
   }
 
+  // Seeded below. This test previously assumed the address was already in the
+  // database, which only held true against a dev database with leftover data.
+  const existingUser = {
+    email: "existingemail@gmail.com",
+    password: "test"
+  }
+
   beforeAll(async ()=>{
     testServer = new ApolloServer({ schema } as any)
 
@@ -28,8 +35,13 @@ describe("Login/Register", ()=>{
     // make sure the test user does not already exits (already registered)
     const response = await UserModel.find({email: user.email}).catch()
     if(response.length>0) await UserModel.findByIdAndDelete(response.at(0)._id) //remove from db if exists
+
+    await UserModel.deleteMany({email: existingUser.email})
+    await UserModel.create({...existingUser, token: "existingUserNonJWTTestToken"})
   })
   afterAll(async ()=>{
+    await UserModel.deleteMany({email: {$in: [user.email, existingUser.email]}})
+
     await testServer.stop()
     await disconnect()
   })
@@ -43,13 +55,9 @@ describe("Login/Register", ()=>{
     expect(response.data?.registerUser.email).toBe(user.email)
   })
   it("Register: reject already existing user email", async ()=>{
-    const alreadyExistingUser = {
-      email: "existingemail@gmail.com",
-      password: "test"
-    }
     const response = await testServer.executeOperation({
       query: UserQueries.REGISTER_USER,
-      variables: { email: alreadyExistingUser.email, password: alreadyExistingUser.password}
+      variables: { email: existingUser.email, password: existingUser.password}
     })
     expect(response.errors?.at(0)?.extensions?.code).toBe(ERROR_LIST.ALREADY_EXISTS.code)
   })


### PR DESCRIPTION
## Summary

The server suite only passed against a dev database with leftover data, and the scale tests were exercising an API that no longer exists. This makes them pass from scratch, which unblocks CI as a merge gate.

Apollo Server defaults `context` to `{}` — truthy — so `if(!ctx)` never fired and every scale resolver ran with `ctx.id === undefined`, quietly operating on a nonexistent user. The tests also passed a `userId` variable the schema stopped declaring when auth moved to the JWT, so GraphQL silently discarded it.

Result: 10 passed, 3 todo, 13 total — 2/2 suites, 57s, no hang.

- [x] Ran it end to end — note how, if CI doesn't cover it (device run, live host, tailnet)

Verified by CI on this PR rather than locally: Docker isn't available in my WSL distro, so I couldn't run MongoDB to execute the suite.

## Screenshots

n/a

## Follow-ups

- **Resolver bug, left unfixed deliberately:** `UserModel.findById(ctx.id)` resolves to `null` for a missing document rather than rejecting, so the `.catch` in `Scale.ts:70`, `:117` and `:145` never runs and `NOT_FOUND` is never thrown for a user that no longer exists. The three assertions that covered this are `it.todo` until the resolvers check for null — that behavior change deserves its own review.
- `GET_SCALES` maps scales through a stored `ScaleOrder`; a stale id in that list yields a null entry in a non-null list. Tests work around it by clearing the order, but the resolver could filter instead.
- Mobile typecheck is still `continue-on-error` — pre-existing Metro-alias and StyleSheet typing errors.
