### PR TITLE
chore(mobile): bump @apollo/client from 3 to 4.2.8

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -8,7 +8,7 @@
       "name": "motivation-measurement-tool-app",
       "version": "1.0.0",
       "dependencies": {
-        "@apollo/client": "^3.11.10",
+        "@apollo/client": "^4.2.8",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
         "@fortawesome/free-regular-svg-icons": "^6.4.0",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.1.tgz",
-      "integrity": "sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.8.tgz",
+      "integrity": "sha512-Iw/e/5fpOx+/2CgtcFNLdwxtdPzwTfmD4mYRjHA1UBdkfe6WOtWLRQeRESCUJCh49blXwp9I496A0MIoLgmCsw==",
       "license": "MIT",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
@@ -57,20 +57,15 @@
         "@wry/equality": "^0.5.6",
         "@wry/trie": "^0.5.0",
         "graphql-tag": "^2.12.6",
-        "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.18.0",
-        "prop-types": "^15.7.2",
-        "rehackt": "^0.1.0",
-        "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.10.3",
-        "tslib": "^2.3.0",
-        "zen-observable-ts": "^1.2.5"
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^15.0.0 || ^16.0.0",
+        "graphql": "^16.0.0 || ^17.0.0",
         "graphql-ws": "^5.5.5 || ^6.0.3",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
+        "rxjs": "^7.3.0",
         "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
@@ -6264,24 +6259,6 @@
         "regjsparser": "bin/parser"
       }
     },
-    "node_modules/rehackt": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rehackt/-/rehackt-0.1.0.tgz",
-      "integrity": "sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "*"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6338,6 +6315,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -6717,15 +6704,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/symbol-observable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
-      "integrity": "sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -6849,18 +6827,6 @@
       "resolved": "https://registry.npmjs.org/toqr/-/toqr-0.1.1.tgz",
       "integrity": "sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==",
       "license": "MIT"
-    },
-    "node_modules/ts-invariant": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
-      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -7216,21 +7182,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/zen-observable": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
-      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
-      "license": "MIT"
-    },
-    "node_modules/zen-observable-ts": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
-      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zod": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -8,7 +8,7 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@apollo/client": "^3.11.10",
+    "@apollo/client": "^4.2.8",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/free-regular-svg-icons": "^6.4.0",

--- a/mobile/screens/auth/Login.tsx
+++ b/mobile/screens/auth/Login.tsx
@@ -9,7 +9,7 @@ import { LOGIN_USER } from "../../utils/queries/auth"
 import { useContext, useState } from "react"
 import { AuthContext } from "../../utils/context/authContext"
 import { screens } from "../../utils/screens"
-import { AuthInput, emptyAuthInput } from "../../utils/types/auth"
+import { AuthInput, AuthUser, emptyAuthInput } from "../../utils/types/auth"
 
 export default function LoginScreen({ navigation }: {navigation: any}){
   const context = useContext(AuthContext)
@@ -21,7 +21,7 @@ export default function LoginScreen({ navigation }: {navigation: any}){
     loginUser({variables: values})
   }
 
-  const [loginUser] = useMutation(LOGIN_USER, {
+  const [loginUser] = useMutation<{loginUser: AuthUser}>(LOGIN_USER, {
     onCompleted({loginUser}){
       context.login(loginUser)
       navigation.navigate(screens.Dashboard)

--- a/mobile/screens/auth/Signup.tsx
+++ b/mobile/screens/auth/Signup.tsx
@@ -9,7 +9,7 @@ import { REGISTER_USER } from "../../utils/queries/auth"
 import { useContext, useEffect, useState } from "react"
 import { AuthContext } from "../../utils/context/authContext"
 import { screens } from "../../utils/screens"
-import { AuthInput, emptyAuthInput } from "../../utils/types/auth"
+import { AuthInput, AuthUser, emptyAuthInput } from "../../utils/types/auth"
 
 export default function SignupScreen({ navigation }: {navigation: any}){
   const context = useContext(AuthContext)
@@ -26,8 +26,8 @@ export default function SignupScreen({ navigation }: {navigation: any}){
     registerUser({variables: values})
   }
 
-  const [registerUser] = useMutation(REGISTER_USER, {
-    onCompleted({loginUser: registerUser}){
+  const [registerUser] = useMutation<{registerUser: AuthUser}>(REGISTER_USER, {
+    onCompleted({registerUser}){
       context.login(registerUser)
       navigation.navigate(screens.Dashboard)
     },

--- a/mobile/screens/home/Dashboard.tsx
+++ b/mobile/screens/home/Dashboard.tsx
@@ -21,9 +21,10 @@ export default function App({ navigation, route }: any) {
     scalesRef.current = scales
   },[scales])
 
-  useQuery(ScaleQueries.GET_SCALES, {
-    onCompleted(data){ setScales(data.scales) }
-  })
+  const { data: scalesData } = useQuery<{scales: ScaleData[]}>(ScaleQueries.GET_SCALES)
+  useEffect(()=>{
+    if(scalesData) setScales(scalesData.scales)
+  },[scalesData])
   const [reorderScales] = useMutation(REORDER_SCALES)
 
   useEffect(()=>{

--- a/mobile/screens/home/MutateScale.tsx
+++ b/mobile/screens/home/MutateScale.tsx
@@ -4,14 +4,14 @@ import variables from "../../styles/styles.variables"
 import { screens } from '../../utils/screens';
 import ScaleQueries from '../../utils/queries/scale';
 import { useMutation } from "@apollo/client/react"
-import { ScaleInput } from '../../utils/types/scale';
+import { ScaleData, ScaleInput } from '../../utils/types/scale';
 import useForm from '../../utils/hooks/useForm';
 import { useEffect } from 'react';
 
 export default function MutateScale({route, navigation}: any) {
   const { onChange, values } = useForm<ScaleInput>(route.params)
 
-  const [addScale] = useMutation(ScaleQueries.CREATE_SCALE, {
+  const [addScale] = useMutation<{createScale: ScaleData}>(ScaleQueries.CREATE_SCALE, {
     variables: values,
     onCompleted(data){ 
       navigation.navigate(screens.Dashboard, {mutationType: "add", scale: data.createScale}) 
@@ -20,7 +20,7 @@ export default function MutateScale({route, navigation}: any) {
       console.log(e)
     }
   })
-  const [updateScale] = useMutation(ScaleQueries.UPDATE_SCALE, {
+  const [updateScale] = useMutation<{updateScale: ScaleData}>(ScaleQueries.UPDATE_SCALE, {
     variables: {...route.params.input, ...values},
     onCompleted(data){
       navigation.navigate(screens.Dashboard, {mutationType: "edit", scale: data.updateScale}) 
@@ -29,7 +29,7 @@ export default function MutateScale({route, navigation}: any) {
       console.log(e)
     }
   })
-  const [deleteScale] = useMutation(ScaleQueries.DELETE_SCALE, {
+  const [deleteScale] = useMutation<{deleteScale: ScaleData}>(ScaleQueries.DELETE_SCALE, {
     variables: {id: route.params.input.id},
     onCompleted(data){
       navigation.navigate(screens.Dashboard, {mutationType: "delete", scale: data.deleteScale}) 

--- a/mobile/utils/types/auth.ts
+++ b/mobile/utils/types/auth.ts
@@ -1,3 +1,10 @@
+export type AuthUser = {
+  id: string
+  email: string
+  password: string
+  token: string
+}
+
 export type AuthInput = {
   email: string
   password: string


### PR DESCRIPTION
## Summary

Supersedes #89, which bumped `@apollo/client` 3 → 4 but failed `Mobile typecheck`. The bump itself was fine; v4 types result data as `unknown` instead of `any`, so every callback that destructured a result needed a real type.

- Added an `AuthUser` type and supplied generics to the login/register mutations
- Supplied generics to the create/update/delete scale mutations
- `useQuery` no longer accepts `onCompleted` in v4 (mutations still do), so `GET_SCALES` now reads `data` and syncs through a `useEffect`

### Bug found

The stricter typing exposed a real bug in `Signup.tsx`:

```jsx
onCompleted({loginUser: registerUser}){   // REGISTER_USER returns `registerUser`
  context.login(registerUser)
}
```

`REGISTER_USER` returns a field named `registerUser`, not `loginUser`. This was reading a key that doesn't exist and passing `undefined` into `context.login()`. Apollo 3's `any` typing let it compile silently. Now destructures the correct field.

**Worth testing signup specifically** — if it's been broken, this is why.

- [ ] Ran it end to end — note how, if CI doesn't cover it (device run, live host, tailnet)

Not verified on device. `npm ci` exit 0, `tsc --noEmit` exit 0, `expo install --check` clean.

## Follow-ups

Remaining dependabot PRs and their real blockers:

- **#85** (`@apollo/server` 4 → 5, server) — already green, just needs merging
- **#87** (typescript 7, server) — blocked upstream: `ts-jest@29.4.12` (latest) still peers `typescript >=4.3 <7`
- **#86** (react 19, website) and **#84** (eslint 10, website) — both need Next.js 13 → 16. React 19 requires Next 15+, and `eslint-config-next@16` is what accepts eslint 10. One migration, not two bumps.
